### PR TITLE
fixed treetraversal methods

### DIFF
--- a/Baeume/Tree Traversal/TraverseTree.java
+++ b/Baeume/Tree Traversal/TraverseTree.java
@@ -1,32 +1,45 @@
 public class TraverseTree{
-  public String inOrder (pTree BinaryTree<Character>){
-    String rückgabe = "";
-    if(pTree.getContent == null){
+  public String midOrder(pTree BinaryTree<Character>) {
+    if (pTree == null) return "";
+    
+    if(pTree.getContent() != null) {
+      return 
+        pTree.getContent() +
+        preOrder(pTree.getLeftTree()) + 
+        preOrder(pTree.getRightTree());
     } else {
-      rückgabe = inOrder(pTree.getLeftTree());
-      rückgabe.concat(pTree.getContent());
-      rückgabe.concat(inOrder(pTree.getRightTree()));
+      return
+        preOrder(pTree.getLeftTree()) + 
+        preOrder(pTree.getRightTree());
     }
-    return (rückgabe);
   }
 
-  public String preOrder(pTree BinaryTree<Character>){
-    String rückgabe = "";
-    if(pTree.getContent() != null){
-      rückgabe = preOrder(pTree.getContent() + "");
-      preOrder(pTree.getLeftTree());
-      preOrder(pTree.getRightTree());
+  public String preOrder(pTree BinaryTree<Character>) {
+    if (pTree == null) return "";
+    
+    if(pTree.getContent() != null) {
+      return 
+        pTree.getContent() +
+        preOrder(pTree.getLeftTree()) + 
+        preOrder(pTree.getRightTree());
+    } else {
+      return
+        preOrder(pTree.getLeftTree()) + 
+        preOrder(pTree.getRightTree());
     }
-    return (rückgabe);
   }
 
-  public String postOrder(pTree BinaryTree<Character>){
-    String rückgabe = "";
-    if (pTree.getContent() != null){
-      postOrder(pTree.getLeftTree());
-      postOrder(pTree.getRightTree());
-      rückgabe = pTree.getContent() + " ";
+  public String postOrder(pTree BinaryTree<Character>) {
+    if (pTree == null) return "";
+    
+    if(pTree.getContent() != null) {
+      return
+        preOrder(pTree.getLeftTree()) + 
+        preOrder(pTree.getRightTree()) +
+        pTree.getContent();
+    } else {
+      return
+        preOrder(pTree.getLeftTree()) + 
+        preOrder(pTree.getRightTree());
     }
-    return (rückgabe);
-  }
 }


### PR DESCRIPTION
Due to the root node always having null as its content in this project, the method would always return "".

In the old implementation, data was also being lost by first  concatenating to a string and then assigning a different one to it entirely.